### PR TITLE
Fix dataset path

### DIFF
--- a/fine-tunning-graphcodebert-karnalim-with-features.py
+++ b/fine-tunning-graphcodebert-karnalim-with-features.py
@@ -126,7 +126,7 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained('microsoft/graphcodebert-base')
     
     # Path to the dataset file
-    dataset_path = 'data\data2.json'  # Your dataset path
+    dataset_path = 'data/data2.json'  # Path to the dataset file
     
     # Load the dataset
     full_dataset = CodePairDataset(file_path=dataset_path, tokenizer=tokenizer)


### PR DESCRIPTION
## Summary
- correct dataset path to use forward slashes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197107260832a8abb43a16894abd1